### PR TITLE
환자 검색에 querydsl 적용하여 동적 검색으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ group = 'com.hdjtest'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -16,6 +22,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.projectlombok:lombok:1.18.18'
+
+	// querydsl
+	def queryDSL = '4.2.2'
+	compile("com.querydsl:querydsl-core")
+	compile("com.querydsl:querydsl-jpa")
+	compile("com.querydsl:querydsl-apt")
+	annotationProcessor("com.querydsl:querydsl-apt:${queryDSL}:jpa")
+
+	annotationProcessor("org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.2.Final")
+	annotationProcessor("javax.annotation:javax.annotation-api:1.3.2")
 
 	// 2021.05.11 김민형 - annotationProcessor 없으니 lombok으로 된 Entity 테시트 에러난다.
 	annotationProcessor('org.projectlombok:lombok')
@@ -32,7 +48,25 @@ dependencies {
 	testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine')
 	testRuntimeOnly('org.junit.platform:junit-platform-engine:')
 	testRuntimeOnly('org.junit.platform:junit-platform-commons')
+
 }
+
+// 2021.05.13 김민형 - 아래 주석한 것들은 현재 버전에서 안되는 듯 하다. 다음 다른 버전으로 작업할 때 참고용으로 우선 놔둔다.
+////querydsl 관련
+//def querydslDir = "$buildDir/generated/querydsl"
+//
+//sourceSets {
+//	main.java.srcDir querydslDir
+//}
+//
+
+//compileQuerydsl {
+//	options.annotationProcessorPath = configurations.querydsl
+//}
+//configurations {
+//	querydsl.extendsFrom compileClasspath
+//}
+
 
 test {
 	useJUnitPlatform()

--- a/src/main/java/com/hdjtest/reception/config/QuerydslConfig.java
+++ b/src/main/java/com/hdjtest/reception/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.hdjtest.reception.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/hdjtest/reception/domain/patient/PatientRepository.java
+++ b/src/main/java/com/hdjtest/reception/domain/patient/PatientRepository.java
@@ -1,11 +1,16 @@
 package com.hdjtest.reception.domain.patient;
 
+import com.hdjtest.reception.config.QuerydslConfig;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface PatientRepository extends JpaRepository<Patient, Long> {
+@Import(QuerydslConfig.class)
+public interface PatientRepository extends JpaRepository<Patient, Long>, PatientRepositoryCustom {
 
     @Query("SELECT MAX(p.환자등록번호) FROM Patient p WHERE p.병원.병원ID = ?1")
     String getMaxPatientRegNum(Long 병원ID);
@@ -18,4 +23,8 @@ public interface PatientRepository extends JpaRepository<Patient, Long> {
 
     @Query("SELECT p FROM Patient p WHERE p.생년월일 = ?1")
     List<Patient> selectPatientListByBirth(String 생년월일);
+
+    List<Patient> selectWithOptions(String optionType, String optionValue);
+
+    Optional<Patient> findByName(String 환자명);
 }

--- a/src/main/java/com/hdjtest/reception/domain/patient/PatientRepositoryCustom.java
+++ b/src/main/java/com/hdjtest/reception/domain/patient/PatientRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.hdjtest.reception.domain.patient;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PatientRepositoryCustom {
+
+    Optional<Patient> findByName(String 환자명);
+
+    List<Patient> selectWithOptions(String optionType, String optionValue);
+}

--- a/src/main/java/com/hdjtest/reception/domain/patient/PatientRepositoryImpl.java
+++ b/src/main/java/com/hdjtest/reception/domain/patient/PatientRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.hdjtest.reception.domain.patient;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class PatientRepositoryImpl implements PatientRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Patient> findByName(String 환자명) {
+        Patient patient = jpaQueryFactory.selectFrom(QPatient.patient)
+                        .where(QPatient.patient.환자명.eq(환자명))
+                        .fetchOne();
+
+        return Optional.ofNullable(patient);
+    }
+
+    @Override
+    public List<Patient> selectWithOptions(String optionType, String optionValue) {
+
+        // TODO 2021.05.13 김민형 - 스프링부트에서 예외처리 부분을 정확히 어떻게 하는지 학습이 필요하다.
+        //                         전반적으로 예외처리들을 제대로 못해놓은 상태인데 공통 예외처리 클래스 별도 생성이 필요하다.
+
+        // 2021.05.13 김민형 - Service 단에서 처리되던 것들이 리포지토리 단까지 내려왔다.
+        //                    Service 단에서 쿼리를 생성하는 구조인지 모르기 때문에 우선 구현하는 곳에서 하자.
+        System.out.println(">>>> select options : " +  optionType + ", " +  optionValue);
+
+        JPAQuery<Patient> queryPatientList = jpaQueryFactory.selectFrom(QPatient.patient);
+
+        if (optionType.equals("patient_name")) {
+            queryPatientList.where(QPatient.patient.환자명.eq(optionValue));
+        } else if (optionType.equals("patient_reg_num")) {
+            queryPatientList.where(QPatient.patient.환자등록번호.eq(optionValue));
+        } else if (optionType.equals("patient_birth")) {
+            queryPatientList.where(QPatient.patient.생년월일.eq(optionValue));
+        } else {
+            return null;
+        }
+
+        return queryPatientList.fetch();
+    }
+}

--- a/src/main/java/com/hdjtest/reception/service/svc/patient/PatientService.java
+++ b/src/main/java/com/hdjtest/reception/service/svc/patient/PatientService.java
@@ -27,6 +27,7 @@ public class PatientService {
 
     private final VisitRepository visitRepository;
 
+
     @Transactional(readOnly = true)
     public PatientDto selectById(Long patientId, Boolean includeVisitList) {
         Patient patient = patientRepository.findById(patientId)
@@ -46,19 +47,23 @@ public class PatientService {
     @Transactional(readOnly = true)
     public List<PatientDto> selectDtoAll(String searchType, String searchValue, Boolean includeVisitList) {
         List<PatientDto> patientDtoList = new ArrayList<>();
-        List<Patient> patientList = new ArrayList<Patient>();
 
-        System.out.println(">>>> request params : " +  searchType + ", " +  searchValue);
-        if (searchType.equals("patient_name")) {
-            patientList = patientRepository.selectPatientListByName(searchValue);
-        } else if (searchType.equals("patient_reg_num")) {
-            patientList = patientRepository.selectPatientListByPatientRegNum(searchValue);
-        } else if (searchType.equals("patient_birth")) {
-            patientList = patientRepository.selectPatientListByBirth(searchValue);
-        } else {
-            // 2021.05.12 김민형 - 검색 값이 없는 경우는 반환할게 없다.
-            //patientList = patientRepository.findAll();
-        }
+        // 2021.05.13 김민형 - querydsl 동적검색 사용하는 방식으로 변경하고 리포지토리 단으로 이동
+//        List<Patient> patientList = new ArrayList<Patient>();
+//
+//        System.out.println(">>>> request params : " +  searchType + ", " +  searchValue);
+//        if (searchType.equals("patient_name")) {
+//            patientList = patientRepository.selectPatientListByName(searchValue);
+//        } else if (searchType.equals("patient_reg_num")) {
+//            patientList = patientRepository.selectPatientListByPatientRegNum(searchValue);
+//        } else if (searchType.equals("patient_birth")) {
+//            patientList = patientRepository.selectPatientListByBirth(searchValue);
+//        } else {
+//            // 2021.05.12 김민형 - 검색 값이 없는 경우는 반환할게 없다.
+//            //patientList = patientRepository.findAll();
+//        }
+
+        List<Patient> patientList = patientRepository.selectWithOptions(searchType, searchValue);
 
         System.out.println(">>>> patientList Count : " +  patientList.size());
         // 2021.05.12 김민형 - Mapper 사용을 해야하는데...나중에 리펙토링 필요하다.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,9 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=easy_password
 spring.datasource.initialization-mode=always
-#server.port=8099
+
+# \uC791\uC5C5 PC\uC5D0\uC11C \uAC11\uC790\uAE30 8080 \uD3EC\uD2B8\uAC00 \uC0AC\uC6A9 \uC911\uC774\uB77C\uACE0 \uB098\uC628\uB2E4. \uC5B4\uB290 \uD504\uB85C\uC138\uC2A4\uAC00 \uC0AC\uC6A9 \uC911\uC778\uC9C0 \uCC3E\uAE30 \uADC0\uCC2E\uB2E4. \uC6B0\uC120 \uD3EC\uD2B8 \uBCC0\uACBD\uD574\uC11C \uAC1C\uBC1C \uC9C4\uD589.
+server.port=8099
 
 #Encoding
 server.servlet.encoding.charset=UTF-8

--- a/src/test/java/com/hdjtest/reception/config/TestConfig.java
+++ b/src/test/java/com/hdjtest/reception/config/TestConfig.java
@@ -1,0 +1,19 @@
+package com.hdjtest.reception.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class TestConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/hdjtest/reception/control/patient/PatientControllerTest.java
+++ b/src/test/java/com/hdjtest/reception/control/patient/PatientControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.*;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -26,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 //@Sql(scripts = {"classpath:data/data.sql"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class PatientControllerTest {
+
+    // 2021.05.13 김민형 - 하다보니 Service 단에 대한 단위 테스트인데 Controller 로 이름을 붙였다.
+    //                    다음 플젝에는 MockMvc 를 사용하여 Controller 단 테스트를 만들어야겠다.
+    //                    스프링부트 프로젝트의 경우 현업에서 테스트를 어느 단까지 하는지를 잘 모르겠다.
+
 
     @LocalServerPort
     private int port;
@@ -48,14 +54,6 @@ public class PatientControllerTest {
         assertThat(patientService.selectById(1L, true).getPatientName()).isEqualTo("김민형");
     }
 
-//    void selectPatientWithVisits_Test() throws Exception {
-//
-//        String url = "http://localhost:" + port + "/api/v1/patients/1/visit-all";
-//
-//        ResponseEntity<Long> respEntity = restTemplate.getForEntity(url, patientDto, Long.class);
-//        //assertThat("aaa").isEqualTo("aaa");
-//        assertThat(patientService.selectById(1L).getPatientName()).isEqualTo("김민형");
-//    }
 
     @Test
     void insertPatient_Test() throws Exception {

--- a/src/test/java/com/hdjtest/reception/domain/patient/PatientRepositoryTest.java
+++ b/src/test/java/com/hdjtest/reception/domain/patient/PatientRepositoryTest.java
@@ -1,16 +1,20 @@
 package com.hdjtest.reception.domain.patient;
 
+import com.hdjtest.reception.config.TestConfig;
 import com.hdjtest.reception.domain.base.Hospital;
 
 import com.hdjtest.reception.domain.base.HospitalRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,8 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 //@DataJpaTest
+@Import(TestConfig.class)
 @SpringBootTest
 public class PatientRepositoryTest {
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private HospitalRepository hospitalRepository;
@@ -101,6 +109,15 @@ public class PatientRepositoryTest {
         // 2021.05.11 김민형 - 실패. 분명 성별은 남자였다. 군제대하고 온 복학생이었다.
         //assertThat(patientList.get(3).get성별코드()).isEqualTo("M");
         assertThat(patientList.get(3).get성별코드()).isEqualTo("F");
+    }
 
+    @Test
+    @Transactional
+    void findByName_Test() {
+        Patient patient = patientRepository.findByName("김민형")
+                .orElseThrow(() -> new IllegalArgumentException("Patient 가 존재하지 않습니다. 환자명 : " + "김민형"));
+
+        System.out.println(">>>>> Patient Name : " + patient.get환자명());
+        assertThat(patient.get환자명()).isEqualTo("김민형");
     }
 }


### PR DESCRIPTION
* Sourcetree와 git 커맨드를 사용하다가 1년 이상 사용을 안하고 오랫만에 git 사용을 인텔리제이에서 제공해주는 기능으로 삽질하다가 git 커밋이 복잡해졌습니다. 예전에는 이렇게 쓸데없이 git 형태 복잡하게 만들면 혼났었지요...

1. querydsl 관련 의존성 추가
  1) bundle.gradle에 querydsl 관련 의존성 추가. 근데 그래들 버전마다 세팅 방법이 좀 다른데 버전 별 방법 숙지 필요
  2) JPAQueryFactory에 entityManager 주입되도록 main과 test에 Config 클래스 추가

2. Patient 리포지토리 구조 변경
  1) JPAQueryFactory를 Patient 리포지토리에서 사용할 수 있도록 쿼리 구현 클래스 상속. 앞으로 JPA 관련 쿼리 구현 인터페이스는 클래스 뒤에 Custom을 붙이고 쿼리를 구현하는 클래스는 Impl를 뒤에 붙이도록 정함

 3. PatientService 검색 구조 변경
   - URI 의 쿼리스트링을 분해하는 로직을 Service 단에서 querydsl 동적으로 쿼리문을 생성하도록 하기 위해 Repository 단으로 옮기면서 Repository 단 사용 쿼리 줄어듬

:TODO
1) querydsl 혹은 동적 쿼리문 작성이 가능한 라이브러리를 깊이 학습하여 성능 향상 필요
2) 각 메소드들의 예외처리 전체적으로 정리하여 일괄적으로 처리할 수 있도록 적용 필요
3) 각 클래스와 메소드 단에서 발생하는 로그 내용 통일화 필요. log4j 등 사용 검토
4) 각 api 처리 비용 확인을 위한 모듈 추가 필요